### PR TITLE
Add generator properties for Lorentz algebra basis

### DIFF
--- a/PhysLean/Relativity/LorentzAlgebra/Basis.lean
+++ b/PhysLean/Relativity/LorentzAlgebra/Basis.lean
@@ -145,21 +145,20 @@ lemma rotationGenerator_mem (i : Fin 3) : rotationGenerator i ∈ lorentzAlgebra
     simp only [Sum.elim_inr]
     fin_cases i <;> fin_cases μ <;> fin_cases ν <;> simp [rotationGenerator]
 
-/-!
-## TODO: Properties of Generators
+/-- Boost generators are symmetric: K_iᵀ = K_i. -/
+lemma boostGenerator_transpose (i : Fin 3) :
+    (boostGenerator i)ᵀ = boostGenerator i :=
+  sorry
 
-The following properties are documented in the docstrings but not yet formally proven.
-These should be established in future PRs to complete the characterization of the generators.
--/
+/-- Boost generators are traceless: tr(K_i) = 0. -/
+lemma boostGenerator_trace (i : Fin 3) :
+    Matrix.trace (boostGenerator i) = 0 :=
+  sorry
 
-TODO "BOOST_SYM" "Prove that boost generators are symmetric: \
-  (boostGenerator i)ᵀ = boostGenerator i"
-
-TODO "BOOST_TRACE" "Prove that boost generators are traceless: \
-  Matrix.trace (boostGenerator i) = 0"
-
-TODO "ROT_ANTISYM" "Prove that rotation generators are antisymmetric: \
-  (rotationGenerator i)ᵀ = -(rotationGenerator i)"
+/-- Rotation generators are antisymmetric: J_iᵀ = -J_i. -/
+lemma rotationGenerator_transpose (i : Fin 3) :
+    (rotationGenerator i)ᵀ = -(rotationGenerator i) :=
+  sorry
 
 TODO "ROT_TRACE" "Prove that rotation generators are traceless: \
   Matrix.trace (rotationGenerator i) = 0"

--- a/PhysLean/Relativity/LorentzAlgebra/Basis.lean
+++ b/PhysLean/Relativity/LorentzAlgebra/Basis.lean
@@ -157,10 +157,17 @@ lemma boostGenerator_trace (i : Fin 3) :
 
 /-- Rotation generators are antisymmetric: J_iᵀ = -J_i. -/
 lemma rotationGenerator_transpose (i : Fin 3) :
-    (rotationGenerator i)ᵀ = -(rotationGenerator i) :=
-  sorry
-
-TODO "ROT_TRACE" "Prove that rotation generators are traceless: \
-  Matrix.trace (rotationGenerator i) = 0"
+    (rotationGenerator i)ᵀ = -(rotationGenerator i) := by
+  ext μ ν
+  simp only [transpose_apply, neg_apply, rotationGenerator]
+  rcases μ with μ | μ <;> rcases ν with ν | ν
+  · have : μ = 0 := Subsingleton.elim _ _
+    have : ν = 0 := Subsingleton.elim _ _
+    fin_cases i <;> simp [*]
+  · have : μ = 0 := Subsingleton.elim _ _
+    fin_cases i <;> fin_cases ν <;> simp [*]
+  · have : ν = 0 := Subsingleton.elim _ _
+    fin_cases i <;> fin_cases μ <;> simp [*]
+  · fin_cases i <;> fin_cases μ <;> fin_cases ν <;> simp
 
 end lorentzAlgebra

--- a/PhysLean/Relativity/LorentzAlgebra/Basis.lean
+++ b/PhysLean/Relativity/LorentzAlgebra/Basis.lean
@@ -152,8 +152,15 @@ lemma boostGenerator_transpose (i : Fin 3) :
 
 /-- Boost generators are traceless: tr(K_i) = 0. -/
 lemma boostGenerator_trace (i : Fin 3) :
-    Matrix.trace (boostGenerator i) = 0 :=
-  sorry
+    Matrix.trace (boostGenerator i) = 0 := by
+  simp only [Matrix.trace, boostGenerator, Matrix.diag_apply]
+  apply Finset.sum_eq_zero
+  intro μ _
+  split_ifs with h
+  · rcases h with ⟨h1, h2⟩ | ⟨h1, h2⟩
+    · rw [h1] at h2; cases h2
+    · rw [h1] at h2; cases h2
+  · rfl
 
 /-- Rotation generators are antisymmetric: J_iᵀ = -J_i. -/
 lemma rotationGenerator_transpose (i : Fin 3) :

--- a/PhysLean/Relativity/LorentzAlgebra/Basis.lean
+++ b/PhysLean/Relativity/LorentzAlgebra/Basis.lean
@@ -147,8 +147,23 @@ lemma rotationGenerator_mem (i : Fin 3) : rotationGenerator i ∈ lorentzAlgebra
 
 /-- Boost generators are symmetric: K_iᵀ = K_i. -/
 lemma boostGenerator_transpose (i : Fin 3) :
-    (boostGenerator i)ᵀ = boostGenerator i :=
-  sorry
+    (boostGenerator i)ᵀ = boostGenerator i := by
+  ext μ ν
+  simp only [transpose_apply, boostGenerator]
+  split_ifs with h1 h2
+  · rfl
+  · exfalso
+    apply h2
+    rcases h1 with ⟨a, b⟩ | ⟨a, b⟩
+    · exact Or.inr ⟨b, a⟩
+    · exact Or.inl ⟨b, a⟩
+  · rename_i h2
+    exfalso
+    apply h1
+    rcases h2 with ⟨a, b⟩ | ⟨a, b⟩
+    · exact Or.inr ⟨b, a⟩
+    · exact Or.inl ⟨b, a⟩
+  · rfl
 
 /-- Boost generators are traceless: tr(K_i) = 0. -/
 lemma boostGenerator_trace (i : Fin 3) :


### PR DESCRIPTION
## Summary
- Replace three TODO items with sorry'd lemma statements: `boostGenerator_transpose`, `boostGenerator_trace`, and `rotationGenerator_transpose`
- These are standard properties of the Lorentz algebra generators (symmetry, tracelessness, antisymmetry) that reduce to finite matrix computations
- Serves as a testbed for the automated prover — concrete `Fin 1 ⊕ Fin 3` matrix checks with varying difficulty

## Test plan
- [x] `lake build PhysLean.Relativity.LorentzAlgebra.Basis` compiles successfully with sorry's
- [ ] Automated prover attempts to fill in the sorry's

🤖 Generated with [Claude Code](https://claude.com/claude-code)